### PR TITLE
Change semantic of Active to Verified

### DIFF
--- a/authman/db.lua
+++ b/authman/db.lua
@@ -37,12 +37,6 @@ function db.configurate(config)
         })
         password_space:create_index(password.PRIMARY_INDEX, {
             type = 'hash',
-            parts = {password.ID, 'string'},
-            if_not_exists = true
-        })
-        password_space:create_index(password.USER_ID_INDEX, {
-            type = 'tree',
-            unique = true,
             parts = {password.USER_ID, 'string'},
             if_not_exists = true
         })

--- a/authman/db.lua
+++ b/authman/db.lua
@@ -6,6 +6,7 @@ function db.configurate(config)
 
     local user = require('authman.model.user').model(config)
     local password = require('authman.model.password').model(config)
+    local activation_token = require('authman.model.activation_token').model(config)
     local password_token = require('authman.model.password_token').model(config)
     local social = require('authman.model.social').model(config)
     local session = require('authman.model.session').model(config)
@@ -29,6 +30,15 @@ function db.configurate(config)
             type = 'tree',
             unique = false,
             parts = {user.EMAIL, 'string', user.TYPE, 'unsigned'},
+            if_not_exists = true
+        })
+
+        local activation_token_space = box.schema.space.create(activation_token.SPACE_NAME, {
+            if_not_exists = true
+        })
+        activation_token_space:create_index(activation_token.PRIMARY_INDEX, {
+            type = 'hash',
+            parts = {activation_token.USER_ID, 'string'},
             if_not_exists = true
         })
 

--- a/authman/error.lua
+++ b/authman/error.lua
@@ -9,7 +9,7 @@ error.WRONG_ACTIVATION_CODE = '6'
 error.WRONG_SESSION_SIGN = '7'
 error.NOT_AUTHENTICATED = '8'
 error.WRONG_RESTORE_TOKEN = '9'
-error.USER_ALREADY_ACTIVE = '10'
+error.USER_ALREADY_VERIFIED = '10'
 error.WRONG_AUTH_CODE = '11'
 error.IMPROPERLY_CONFIGURED = '12'
 error.WRONG_PROVIDER = '13'
@@ -23,18 +23,19 @@ error.OAUTH_CODE_NOT_FOUND = '20'
 error.OAUTH_ACCESS_TOKEN_NOT_FOUND = '21'
 error.PASSWORD_ALREADY_EXISTS = '22'
 error.PASSWORD_REQUIRED = '23'
+error.USER_NOT_VERIFIED = '24'
 
 error.CODES = {
     [error.USER_NOT_FOUND] = 'User not found',
     [error.USER_ALREADY_EXISTS] = 'User already exists',
     [error.INVALID_PARAMS] = 'Invalid params',
-    [error.USER_NOT_ACTIVE] = 'User not activated',
+    [error.USER_NOT_ACTIVE] = 'User not active',
     [error.WRONG_PASSWORD] = 'Wrong password',
     [error.WRONG_ACTIVATION_CODE] = 'Wrong activation code',
     [error.WRONG_SESSION_SIGN] = 'Wrong session sign',
-    [error.NOT_AUTHENTICATED] = 'User is not authenticated',
+    [error.NOT_AUTHENTICATED] = 'User not authenticated',
     [error.WRONG_RESTORE_TOKEN] = 'Wrong restore token',
-    [error.USER_ALREADY_ACTIVE] = 'User already active',
+    [error.USER_ALREADY_VERIFIED] = 'User already verified',
     [error.WRONG_AUTH_CODE] = 'Wrong auth code',
     [error.IMPROPERLY_CONFIGURED] = 'Wrong config passed',
     [error.WRONG_PROVIDER] = 'Wrong social provider',
@@ -46,8 +47,9 @@ error.CODES = {
     [error.OAUTH_MAX_APPS_REACHED] = 'Max oauth apps limit reached',
     [error.OAUTH_CODE_NOT_FOUND] = 'OAUTH authorization code not found',
     [error.OAUTH_ACCESS_TOKEN_NOT_FOUND] = 'OAUTH access token not found',
-	[error.PASSWORD_ALREADY_EXISTS] = 'Password already exists',
-	[error.PASSWORD_REQUIRED] = 'Password required'
+    [error.PASSWORD_ALREADY_EXISTS] = 'Password already exists',
+    [error.PASSWORD_REQUIRED] = 'Password required',
+    [error.USER_NOT_VERIFIED] = 'User not verified',
 }
 
 return error

--- a/authman/error.lua
+++ b/authman/error.lua
@@ -21,9 +21,7 @@ error.OAUTH_CONSUMER_NOT_FOUND = '18'
 error.OAUTH_MAX_APPS_REACHED = '19'
 error.OAUTH_CODE_NOT_FOUND = '20'
 error.OAUTH_ACCESS_TOKEN_NOT_FOUND = '21'
-error.PASSWORD_ALREADY_EXISTS = '22'
-error.PASSWORD_REQUIRED = '23'
-error.USER_NOT_VERIFIED = '24'
+error.USER_NOT_VERIFIED = '22'
 
 error.CODES = {
     [error.USER_NOT_FOUND] = 'User not found',
@@ -47,8 +45,6 @@ error.CODES = {
     [error.OAUTH_MAX_APPS_REACHED] = 'Max oauth apps limit reached',
     [error.OAUTH_CODE_NOT_FOUND] = 'OAUTH authorization code not found',
     [error.OAUTH_ACCESS_TOKEN_NOT_FOUND] = 'OAUTH access token not found',
-    [error.PASSWORD_ALREADY_EXISTS] = 'Password already exists',
-    [error.PASSWORD_REQUIRED] = 'Password required',
     [error.USER_NOT_VERIFIED] = 'User not verified',
 }
 

--- a/authman/model/activation_token.lua
+++ b/authman/model/activation_token.lua
@@ -1,0 +1,59 @@
+local activation_token = {}
+
+local digest = require('digest')
+local validator = require('authman.validator')
+
+
+-----
+-- token (user_id, code)
+-----
+function activation_token.model(config)
+    local model = {}
+
+    model.SPACE_NAME = config.spaces.activation_token.name
+
+    model.PRIMARY_INDEX = 'primary'
+
+    model.USER_ID = 1
+    model.CODE = 2
+
+    function model.get_space()
+        return box.space[model.SPACE_NAME]
+    end
+
+    function model.get_by_user_id(user_id)
+        return model.get_space():get(user_id)
+    end
+
+    function model.delete(user_id)
+        if validator.not_empty_string(user_id) then
+            return model.get_space():delete({user_id})
+        end
+    end
+
+    local function get_expiration_time()
+        return os.time() + config.change_lifetime
+    end
+
+    function model.generate(user_id)
+        local token = digest.md5_hex(user_id .. os.time() .. config.activation_secret)
+        model.get_space():upsert({user_id, token}, {{'=', 2, token}})
+        return token
+    end
+
+    function model.is_valid(user_token, user_id)
+        local token_tuple = model.get_by_user_id(user_id)
+        if token_tuple and token_tuple[2] == user_token then
+            return true
+        end
+        return false
+    end
+
+    function model.delete(user_id)
+        return model.get_space():delete(user_id)
+    end
+
+    return model
+end
+
+return activation_token

--- a/authman/model/password.lua
+++ b/authman/model/password.lua
@@ -62,13 +62,13 @@ function password.model(config)
     function model.get_by_user_id(user_id)
         if validator.not_empty_string(user_id) then
             -- TODO create index and migrations
-            return model.get_space().index[model.USER_ID_INDEX]:select({user_id})[1]
+            return model.get_space():get(user_id)
         end
     end
 
     function model.delete_by_user_id(user_id)
         if validator.not_empty_string(user_id) then
-            return model.get_space().index[model.USER_ID_INDEX]:delete({user_id})
+            return model.get_space():delete({user_id})
         end
     end
 
@@ -86,7 +86,6 @@ function password.model(config)
     end
 
     function model.create(password_tuple)
-        local id = uuid.str()
         return model.get_space():insert({
             password_tuple[model.USER_ID],
             password_tuple[model.HASH],

--- a/authman/model/password.lua
+++ b/authman/model/password.lua
@@ -1,7 +1,6 @@
 local password = {}
 
 local digest = require('digest')
-local uuid = require('uuid')
 local validator = require('authman.validator')
 local utils = require('authman.utils.utils')
 
@@ -52,18 +51,12 @@ function password.model(config)
     model.SPACE_NAME = config.spaces.password.name
 
     model.PRIMARY_INDEX = 'primary'
-    model.USER_ID_INDEX = 'user'
 
-    model.ID = 1
-    model.USER_ID = 2
-    model.HASH = 3
+    model.USER_ID = 1
+    model.HASH = 2
 
     function model.get_space()
         return box.space[model.SPACE_NAME]
-    end
-
-    function model.get_by_id(id)
-        return model.get_space():get(id)
     end
 
     function model.get_by_user_id(user_id)
@@ -95,17 +88,16 @@ function password.model(config)
     function model.create(password_tuple)
         local id = uuid.str()
         return model.get_space():insert({
-            id,
             password_tuple[model.USER_ID],
             password_tuple[model.HASH],
         })
     end
 
     function model.update(password_tuple)
-        local social_id, fields
-        social_id = password_tuple[model.ID]
+        local user_id, fields
+        user_id = password_tuple[model.USER_ID]
         fields = utils.format_update(password_tuple)
-        return model.get_space():update(social_id, fields)
+        return model.get_space():update(user_id, fields)
     end
 
     function model.create_or_update(password_tuple)
@@ -114,7 +106,6 @@ function password.model(config)
         if exists_password_tuple == nil then
             return model.create(password_tuple)
         else
-            password_tuple[model.ID] = exists_password_tuple[model.ID]
             return model.update(password_tuple)
         end
     end

--- a/authman/model/password_token.lua
+++ b/authman/model/password_token.lua
@@ -15,7 +15,7 @@ function password_token.model(config)
 
     model.USER_ID = 1
     model.CODE = 2
-	model.EXPIRY = 3
+    model.EXPIRY = 3
 
     function model.get_space()
         return box.space[model.SPACE_NAME]
@@ -31,13 +31,13 @@ function password_token.model(config)
         end
     end
 
-	local function get_expiration_time()
+    local function get_expiration_time()
         return os.time() + config.restore_lifetime
     end
 
     function model.generate(user_id)
         local token = digest.md5_hex(user_id .. os.time() .. config.restore_secret)
-		local expiry = get_expiration_time()
+        local expiry = get_expiration_time()
         model.get_space():upsert({user_id, token, expiry}, {{'=', 2, token}, {'=', 3, expiry}})
         return token
     end

--- a/authman/model/user.lua
+++ b/authman/model/user.lua
@@ -6,7 +6,7 @@ local validator =  require('authman.validator')
 local utils = require('authman.utils.utils')
 
 -----
--- user (uuid, email, type, is_active, profile)
+-- user (uuid, email, type, profile)
 -----
 function user.model(config)
     local model = {}
@@ -18,7 +18,6 @@ function user.model(config)
     model.ID = 1
     model.EMAIL = 2
     model.TYPE = 3
-    model.IS_ACTIVE = 4
     model.PROFILE = 5
     model.REGISTRATION_TS = 6    -- date of auth.registration or auth.complete_registration
     model.SESSION_UPDATE_TS = 7  -- date of auth.auth, auth.social_auth or auth.check_auth if session was updated
@@ -38,7 +37,6 @@ function user.model(config)
         local user_data = {
             id = user_tuple[model.ID],
             email = user_tuple[model.EMAIL],
-            is_active = user_tuple[model.IS_ACTIVE],
             profile = user_tuple[model.PROFILE],
         }
         if data ~= nil then
@@ -88,7 +86,6 @@ function user.model(config)
             user_id,
             email,
             user_tuple[model.TYPE],
-            user_tuple[model.IS_ACTIVE],
             user_tuple[model.PROFILE],
             user_tuple[model.REGISTRATION_TS],
             user_tuple[model.SESSION_UPDATE_TS],
@@ -117,12 +114,8 @@ function user.model(config)
         local user_tuple = model.get_by_id(user_id)
         model.delete(user_id)
 
-        model.create_or_update()
+        model.create_or_update(user_tuple)
         return model.get_space():update(user_id, {{'=', model.ID, new_user_id}})
-    end
-
-    function model.generate_activation_code(user_id)
-        return digest.md5_hex(string.format('%s%s', config.activation_secret, user_id))
     end
 
     function model.update_session_ts(user_tuple)

--- a/authman/model/user.lua
+++ b/authman/model/user.lua
@@ -18,9 +18,9 @@ function user.model(config)
     model.ID = 1
     model.EMAIL = 2
     model.TYPE = 3
-    model.PROFILE = 5
-    model.REGISTRATION_TS = 6    -- date of auth.registration or auth.complete_registration
-    model.SESSION_UPDATE_TS = 7  -- date of auth.auth, auth.social_auth or auth.check_auth if session was updated
+    model.PROFILE = 4
+    model.REGISTRATION_TS = 5    -- date of auth.registration or auth.complete_registration
+    model.SESSION_UPDATE_TS = 6  -- date of auth.auth, auth.social_auth or auth.check_auth if session was updated
 
     model.PROFILE_FIRST_NAME = 'first_name'
     model.PROFILE_LAST_NAME = 'last_name'

--- a/authman/oauth/oauth.lua
+++ b/authman/oauth/oauth.lua
@@ -6,6 +6,7 @@ return function(config)
     local api = {}
 
     local user = require('authman.model.user').model(config)
+    local activation_token = require('authman.model.activation_token').model(config)
     local oauth_app = require('authman.model.oauth.app').model(config)
     local oauth_consumer = require('authman.model.oauth.consumer').model(config)
     local oauth_code = require('authman.model.oauth.code').model(config)
@@ -20,8 +21,8 @@ return function(config)
             return response.error(error.USER_NOT_FOUND)
         end
 
-        if not user_tuple[user.IS_ACTIVE] then
-            return response.error(error.USER_NOT_ACTIVE)
+        if activation_token.get_by_user_id(user_tuple[user.ID]) then
+            return response.error(error.USER_NOT_VERIFIED)
         end
 
         if not validator.not_empty_string(app_name)

--- a/authman/validator.lua
+++ b/authman/validator.lua
@@ -31,6 +31,7 @@ local password_strength = {
 }
 
 local config_default_values = {
+    restore_lifetime = 60 * 60 * 24 * 7,
     session_lifetime = 7 * 24 * 60 * 60,
     session_update_timedelta = 2 * 24 * 60 * 60,
     social_check_time = 60 * 60 * 24,

--- a/authman/validator.lua
+++ b/authman/validator.lua
@@ -48,6 +48,7 @@ local config_default_secrets = {
 local config_default_space_names = {
     password = 'auth_password_credential',
     password_token = 'auth_password_token',
+    activation_token = 'auth_activation_token',
     session = 'auth_sesssion',
     social = 'auth_social_credential',
     user = 'auth_user',

--- a/config/config.default.lua
+++ b/config/config.default.lua
@@ -20,6 +20,9 @@ return {
         password_token = {
             name = 'auth_password_token',
         },
+        activation_token = {
+            name = 'auth_activation_token',
+        },
         session = {
             name = 'auth_sesssion',
         },

--- a/config/config.default.lua
+++ b/config/config.default.lua
@@ -4,7 +4,7 @@ return {
     activation_secret = 'ehbgrTUHIJ7689fyvg',
     session_secret = 'aswfWERVefver324efv',
     restore_secret = 'ybhinjTRCFYVGUHB5678jh',
-	restore_lifetime = 60 * 60 * 24 * 7,
+    restore_lifetime = 60 * 60 * 24 * 7,
     session_lifetime = 60 * 60 * 24 * 14,
     session_update_timedelta = 60 * 60 * 24 * 7,
     social_check_time = 60 * 60 * 24,

--- a/config/config.default.lua
+++ b/config/config.default.lua
@@ -4,6 +4,7 @@ return {
     activation_secret = 'ehbgrTUHIJ7689fyvg',
     session_secret = 'aswfWERVefver324efv',
     restore_secret = 'ybhinjTRCFYVGUHB5678jh',
+	restore_lifetime = 60 * 60 * 24 * 7,
     session_lifetime = 60 * 60 * 24 * 14,
     session_update_timedelta = 60 * 60 * 24 * 7,
     social_check_time = 60 * 60 * 24,

--- a/test/case/auth.lua
+++ b/test/case/auth.lua
@@ -36,7 +36,7 @@ function test_auth_success()
     session = user['session']
     user['id'] = nil
     user['session'] = nil
-    expected = {email = 'test@test.ru', is_active = true}
+    expected = {email = 'test@test.ru'}
     test:is(ok, true, 'test_auth_success user logged in')
     test:isstring(session, 'test_auth_success session returned')
     test:is_deeply(user, expected, 'test_auth_success user returned')
@@ -50,7 +50,7 @@ function test_check_auth_success()
     session = user['session']
     user['id'] = nil
     user['session'] = nil
-    expected = {email = 'test@test.ru', is_active = true }
+    expected = {email = 'test@test.ru'}
     test:is(ok, true, 'test_check_auth_success user logged in')
     test:isstring(session, 'test_check_auth_success session returned')
     test:is_deeply(user, expected, 'test_check_auth_success user returned')

--- a/test/case/auth.lua
+++ b/test/case/auth.lua
@@ -21,6 +21,7 @@ function exports.before()
     ok, user = auth.registration('test@test.ru')
     auth.complete_registration('test@test.ru', user.code, v.USER_PASSWORD)
     ok, user = auth.registration('not_active@test.ru')
+    ok, user = auth.registration('not_verified@test.ru', v.USER_PASSWORD)
 end
 
 function exports.after()
@@ -97,17 +98,22 @@ function test_check_auth_user_not_found()
 end
 
 function test_check_auth_user_not_active()
-    local ok, user, id, session, got, expected
-    ok, user = auth.auth('test@test.ru', v.USER_PASSWORD)
-    id = user['id']
-    session = user['session']
-
-    user_space:update(id, {{'=', 4, false}})
-
-    got = {auth.check_auth(session), }
+    local got, expected
+    got = {auth.auth('not_active@test.ru', v.USER_PASSWORD), }
     expected = {response.error(error.USER_NOT_ACTIVE), }
     test:is_deeply(got, expected, 'test_check_auth_user_not_active')
 end
+
+
+function test_check_auth_user_not_verified_login()
+    local ok, user, id, session, got, expected
+    ok, user = auth.auth('not_verified@test.ru', v.USER_PASSWORD)
+    id = user['id']
+    session = user['session']
+    ok, user = auth.check_auth(session)
+    test:is(ok, true, 'test_check_auth_user_not_verified_login success')
+end
+
 
 function test_check_auth_empty_session()
     local ok, user, got, expected

--- a/test/case/profile.lua
+++ b/test/case/profile.lua
@@ -33,7 +33,7 @@ function test_set_profile_success()
     ok, user = auth.set_profile(user['id'], user_profile)
 
     user['id'] = nil
-    expected = {email = 'test@test.ru', is_active = true, profile=user_profile}
+    expected = {email = 'test@test.ru', profile=user_profile}
     test:is(ok, true, 'test_set_profile_success user returned')
     test:is_deeply(user, expected, 'test_set_profile_success profile set')
 end
@@ -63,7 +63,7 @@ function test_set_profile_user_not_verified()
     user_profile = {last_name='test_last', first_name='test_first' }
 
     got = {auth.set_profile(id, user_profile), }
-    expected = {response.error(error.USER_NOT_VERIFIED, }
+    expected = {response.error(error.USER_NOT_VERIFIED), }
     test:is_deeply(got, expected, 'test_set_profile_user_not_verified')
 end
 
@@ -77,7 +77,7 @@ function test_get_profile_success()
     ok, user = auth.get_profile(user['id'])
 
     user['id'] = nil
-    expected = {email = 'test@test.ru', is_active = true, profile=user_profile}
+    expected = {email = 'test@test.ru', profile=user_profile}
     test:is(ok, true, 'test_get_profile_success user returned')
     test:is_deeply(user, expected, 'test_get_profile_success profile')
 end
@@ -107,7 +107,7 @@ function test_delete_user_success()
     ok, user = auth.delete_user(user['id'])
     id = user['id']
     user['id'] = nil
-    expected = {email = 'test@test.ru', is_active = true}
+    expected = {email = 'test@test.ru'}
     test:is(ok, true, 'test_delete_user_success user deleted')
     test:is_deeply(user, expected, 'test_delete_user_success profile returned')
 
@@ -139,7 +139,7 @@ exports.tests = {
 
     test_set_profile_invalid_id,
     test_set_profile_user_not_found,
-    test_set_profile_user_not_active,
+    test_set_profile_user_not_verified,
     test_get_profile_invalid_id,
     test_get_profile_user_not_found,
     test_delete_user_invalid_id,

--- a/test/case/profile.lua
+++ b/test/case/profile.lua
@@ -56,18 +56,15 @@ function test_set_profile_user_not_found()
     test:is_deeply(got, expected, 'test_set_user_not_found')
 end
 
-function test_set_profile_user_not_active()
+function test_set_profile_user_not_verified()
     local got, expected, user_profile, ok, code, user, id
-    ok, user = auth.registration('test@test.ru')
-    ok, user = auth.complete_registration('test@test.ru', user.code, v.USER_PASSWORD)
+    ok, user = auth.registration('test@test.ru', v.USER_PASSWORD)
     id = user['id']
-
-    user_space:update(id, {{'=', 4, false}})
     user_profile = {last_name='test_last', first_name='test_first' }
 
     got = {auth.set_profile(id, user_profile), }
-    expected = {response.error(error.USER_NOT_ACTIVE), }
-    test:is_deeply(got, expected, 'test_set_profile_user_not_active')
+    expected = {response.error(error.USER_NOT_VERIFIED, }
+    test:is_deeply(got, expected, 'test_set_profile_user_not_verified')
 end
 
 function test_get_profile_success()

--- a/test/case/registration.lua
+++ b/test/case/registration.lua
@@ -93,14 +93,14 @@ function test_complete_registration_weak_password()
     test:is_deeply(got, expected, 'test_complete_registration_weak_password 3')
 end
 
-function test_complete_registration_user_already_active()
+function test_complete_registration_user_already_verified()
     local ok, user, got, expected, user, code
     ok, user = auth.registration('test@test.ru')
     code = user.code
     ok, user = auth.complete_registration('test@test.ru', code, v.USER_PASSWORD)
     got = {auth.complete_registration('test@test.ru', code, v.USER_PASSWORD), }
-    expected = {response.error(error.USER_ALREADY_ACTIVE), }
-    test:is_deeply(got, expected, 'test_complete_registration_user_already_active')
+    expected = {response.error(error.USER_ALREADY_VERIFIED), }
+    test:is_deeply(got, expected, 'test_complete_registration_user_already_verified')
 end
 
 function test_complete_registration_user_not_found()
@@ -133,28 +133,11 @@ end
 function test_registration_user_not_active_alternate_password_success()
     local ok, user
     ok, user = auth.registration('test@test.ru', v.USER_PASSWORD)
+    -- should not allow in app
     ok, user = auth.registration('test_exists@test.ru')
     test:is(ok, true, 'test_registartion_user_not_active_success user created')
     test:isstring(user.code, 'test_registartion_user_not_active_success code returned')
     test:is(user.email, 'test_exists@test.ru', 'test_registartion_user_not_active_success email returned')
-end
-
-
-function test_complete_registration_no_password_fails()
-    local ok, user, got, expected
-    ok, user = auth.registration('test@test.ru')
-    got = {auth.complete_registration('test@test.ru', user.code)}
-    expected = {response.error(error.PASSWORD_REQUIRED) }
-    test:is_deeply(got, expected, 'test_complete_registration_no_password_fails')
-end
-
-
-function test_complete_registration_repeated_password_fails()
-    local ok, user, got, expected
-    ok, user = auth.registration('test@test.ru', v.USER_PASSWORD)
-    got = {auth.complete_registration('test@test.ru', user.code, v.USER_PASSWORD)}
-    expected = {response.error(error.PASSWORD_ALREADY_EXISTS) }
-    test:is_deeply(got, expected, 'test_complete_registration_repeated_password_fails')
 end
 
 
@@ -171,10 +154,8 @@ exports.tests = {
     test_complete_registration_user_not_found,
     test_complete_registration_empty_code,
 
-	test_complete_registration_password_success,
-	test_registration_user_not_active_alternate_password_success,
-	test_complete_registration_no_password_fails,
-	test_complete_registration_repeated_password_fails,
+    test_complete_registration_password_success,
+    test_registration_user_not_active_alternate_password_success,
 }
 
 return exports

--- a/test/case/registration.lua
+++ b/test/case/registration.lua
@@ -44,10 +44,9 @@ function test_complete_registration_succes()
     local ok, user
     ok, user = auth.registration('test@test.ru')
     ok, user = auth.complete_registration('test@test.ru', user.code, v.USER_PASSWORD)
-
     user['id'] = nil -- remove random id
     test:is(ok, true, 'test_complete_registration_succes activated success')
-    test:is_deeply(user, {email = 'test@test.ru', is_active = true}, 'test_complete_registration_succes user returned')
+    test:is_deeply(user, {email = 'test@test.ru'}, 'test_complete_registration_succes user returned')
 end
 
 function test_registration_invalid_email()
@@ -126,7 +125,7 @@ function test_complete_registration_password_success()
 
     user['id'] = nil -- remove random id
     test:is(ok, true, 'test_complete_registration_password_succes activated success')
-    test:is_deeply(user, {email = 'test@test.ru', is_active = true}, 'test_complete_registration_password_succes user returned')
+    test:is_deeply(user, {email = 'test@test.ru'}, 'test_complete_registration_password_succes user returned')
 end
 
 
@@ -150,7 +149,7 @@ exports.tests = {
     test_registration_user_already_active,
     test_complete_registration_wrong_code,
     test_complete_registration_weak_password,
-    test_complete_registration_user_already_active,
+    test_complete_registration_user_already_verified,
     test_complete_registration_user_not_found,
     test_complete_registration_empty_code,
 

--- a/test/case/restore_password.lua
+++ b/test/case/restore_password.lua
@@ -1,5 +1,6 @@
 local exports = {}
 local tap = require('tap')
+local fiber = require('fiber')
 local response = require('authman.response')
 local error = require('authman.error')
 local validator = require('authman.validator')
@@ -147,6 +148,18 @@ function test_complete_restore_password_empty_token()
     test:is_deeply(got, expected, 'test_complete_restore_password_empty_token')
 end
 
+
+function test_complete_restore_passsword_expired_token()
+    local ok, token, id, session, got, expected
+    ok, token = auth.restore_password('test@test.ru')
+    fiber.sleep(config.session_lifetime)
+
+    got = {auth.complete_restore_password('test@test.ru', token, 'new_pwd'), }
+    expected = {response.error(error.WRONG_RESTORE_TOKEN), }
+    test:is_deeply(got, expected, 'test_complete_restore_password_expired_token')
+
+end
+
 exports.tests = {
     test_restore_password_success,
     test_complete_restore_password_success,
@@ -160,6 +173,7 @@ exports.tests = {
     test_complete_restore_password_wrong_token,
     test_complete_restore_password_auth_with_old_password,
     test_complete_restore_password_empty_token,
+	test_complete_restore_passsword_expired_token,
 }
 
 return exports

--- a/test/case/restore_password.lua
+++ b/test/case/restore_password.lua
@@ -45,7 +45,7 @@ function test_complete_restore_password_success()
     ok, user = auth.complete_restore_password('test@test.ru', token, 'new_pwd')
     nok, _ = auth.check_auth(session)
     user['id'] = nil
-    expected = {email = 'test@test.ru', is_active = true}
+    expected = {email = 'test@test.ru'}
     test:is(ok, true, 'test_complete_restore_password_success password changed')
     test:is(nok, false, 'test_complete_restore_password_success session dropped')
     test:is_deeply(user, expected, 'test_complete_restore_password_success user returned')
@@ -59,7 +59,7 @@ function test_complete_restore_password_and_auth_success()
     session = user['session']
     user['id'] = nil
     user['session'] = nil
-    expected = {email = 'test@test.ru', is_active = true}
+    expected = {email = 'test@test.ru'}
     test:is(ok, true, 'test_complete_restore_password_and_auth_success user logged in')
     test:isstring(session, 'test_complete_restore_password_and_auth_success session returned')
     test:is_deeply(user, expected, 'test_complete_restore_password_and_auth_success user returned')
@@ -109,6 +109,8 @@ function test_complete_restore_passsword_weak()
     test:is_deeply(got, expected, 'test_complete_restore_passsword_weak 3')
 end
 
+--[[  Flow will not happen
+
 function test_complete_restore_password_user_not_active()
     local ok, token, id, session, got, expected
     ok, token = auth.restore_password('test@test.ru')
@@ -121,6 +123,7 @@ function test_complete_restore_password_user_not_active()
     expected = {response.error(error.USER_NOT_ACTIVE), }
     test:is_deeply(got, expected, 'test_complete_restore_password_user_not_active')
 end
+]]
 
 function test_complete_restore_password_wrong_token()
     local ok, token, id, session, got, expected
@@ -169,11 +172,11 @@ exports.tests = {
     test_restore_password_user_not_active,
     test_complete_restore_password_user_not_found,
     test_complete_restore_passsword_weak,
-    test_complete_restore_password_user_not_active,
+    -- test_complete_restore_password_user_not_active,
     test_complete_restore_password_wrong_token,
     test_complete_restore_password_auth_with_old_password,
     test_complete_restore_password_empty_token,
-	test_complete_restore_passsword_expired_token,
+    test_complete_restore_passsword_expired_token,
 }
 
 return exports

--- a/test/case/social.lua
+++ b/test/case/social.lua
@@ -50,7 +50,6 @@ function test_social_auth_success()
 
     expected = {
         email = v.USER_EMAIL,
-        is_active = true,
         social = {
             provider = 'vk',
             social_id = v.SOCIAL_ID
@@ -75,7 +74,6 @@ function test_social_auth_no_email_success()
 
     expected = {
         email = '',
-        is_active = true,
         social = {
             provider = 'vk',
             social_id = v.SOCIAL_ID
@@ -100,7 +98,6 @@ function test_social_auth_no_profile_success()
 
     expected = {
         email = v.USER_EMAIL,
-        is_active = true,
         social = {
             provider = 'vk',
             social_id = v.SOCIAL_ID
@@ -125,7 +122,6 @@ function test_check_auth_social_success()
 
     expected = {
         email = v.USER_EMAIL,
-        is_active = true,
         social = {
             provider = 'vk',
             social_id = v.SOCIAL_ID

--- a/test/config.lua
+++ b/test/config.lua
@@ -5,6 +5,7 @@ return {
     activation_secret = 'ehbgrTUHIJ7689fyvg',
     session_secret = 'aswfWERVefver324efv',
     restore_secret = 'ybhinjTRCFYVGUHB5678jh',
+	restore_lifetime = 3,
     session_lifetime = 3,
     session_update_timedelta = 2,
     social_check_time = 2,

--- a/test/config.lua
+++ b/test/config.lua
@@ -5,7 +5,7 @@ return {
     activation_secret = 'ehbgrTUHIJ7689fyvg',
     session_secret = 'aswfWERVefver324efv',
     restore_secret = 'ybhinjTRCFYVGUHB5678jh',
-	restore_lifetime = 3,
+    restore_lifetime = 3,
     session_lifetime = 3,
     session_update_timedelta = 2,
     social_check_time = 2,


### PR DESCRIPTION
User not active now means not having a password, which maybe a temporary state if the old flow is used, where no password is supplied during sign up.

Why?
- My commerce site allow visitors to select product, then sign up, (which will auto sign in), view cart and checkout, preferably without leaving the site to check activation email, which may cause lost of sale.
- Current flow does not allow password when sign up, so user cannot sign in prior to activation.
- This change allow both flows.
- Added activation_token space, saving a boolean in user space, and non repeating activation token.


Also added expiry to password_token space, and removed unnecessary hash id from password space.
